### PR TITLE
Add PR write permission to GH token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   version:


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow permissions. The change grants write access to pull requests in the `.github/workflows/release.yml` file.