### PR TITLE
Replace unmaintained atty crate with std::io::IsTerminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/bin/oav.rs"
 
 [dependencies]
 anyhow = "1.0.100"
-atty = "0.2.14"
 clap = { version = "4.5.54", features = ["derive"] }
 include_dir = "0.7.4"
 indicatif = "0.18.3"

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,7 @@
 use indicatif::{ProgressBar, ProgressStyle};
 use owo_colors::OwoColorize;
 use std::env;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::time::Duration;
 
 pub struct Output {
@@ -13,7 +13,7 @@ pub struct Output {
 
 impl Output {
     pub fn new(verbose: bool, quiet: bool) -> Self {
-        let is_tty = atty::is(atty::Stream::Stdout);
+        let is_tty = io::stdout().is_terminal();
         let color = is_tty && env::var_os("NO_COLOR").is_none();
         let progress = is_tty && !verbose && !quiet;
         Self {


### PR DESCRIPTION
## Summary
- Removes the deprecated `atty` crate which has a known soundness issue ([RUSTSEC-2024-0375](https://rustsec.org/advisories/RUSTSEC-2024-0375.html))
- Replaces it with `std::io::IsTerminal`, stable since Rust 1.70 (well within our 1.92 MSRV)
- Zero behavior change — same TTY detection, no new dependencies

Closes #24