### PR TITLE
Skip all gitignore management when manage_gitignore is false

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,9 @@ fn cmd_validate(
 ) -> Result<()> {
     let mut cfg = config::load(root)?;
     util::ensure_oav_dir(root)?;
-    util::add_gitignore_entries(root, &[".oav/"])?;
+    if cfg.manage_gitignore {
+        util::add_gitignore_entries(root, &[".oav/"])?;
+    }
     util::extract_assets(root, &ASSETS)?;
     if let Some(s) = spec_override {
         let trimmed = s.trim().to_string();


### PR DESCRIPTION
## Summary
- Gate both `.oav/` and `.oavc` gitignore entries behind the `manage_gitignore` config flag
- Previously `.oav/` was always added to `.gitignore` regardless of the setting

Closes #38