### PR TITLE
Add test coverage, config subcommands, and exit codes

### DIFF
--- a/src/bin/oav.rs
+++ b/src/bin/oav.rs
@@ -1,6 +1,6 @@
 fn main() {
     if let Err(err) = oav::run() {
         eprintln!("{err:#}");
-        std::process::exit(1);
+        std::process::exit(oav::EXIT_INFRA_ERROR);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,10 @@ pub enum ConfigCommand {
     },
     Edit,
     Print,
+    /// Validate the current config file
+    Validate,
+    /// List all supported generators
+    ListGenerators,
     Ignore,
     Unignore,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,26 @@ impl Default for Config {
     }
 }
 
+pub fn validate(config: &Config) -> Result<()> {
+    if config.docker_timeout == 0 {
+        bail!("docker_timeout must be greater than 0");
+    }
+    if config.search_depth == 0 {
+        bail!("search_depth must be greater than 0");
+    }
+    validate_generators(
+        "server",
+        &config.server_generators,
+        &generators::server_names(),
+    )?;
+    validate_generators(
+        "client",
+        &config.client_generators,
+        &generators::client_names(),
+    )?;
+    Ok(())
+}
+
 pub fn load(root: &Path) -> Result<Config> {
     let path = root.join(CONFIG_FILE);
     if !path.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ mod output;
 mod steps;
 mod util;
 
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_VALIDATION_FAILURE: i32 = 1;
+pub const EXIT_INFRA_ERROR: i32 = 2;
+
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use include_dir::{Dir, include_dir};
@@ -156,6 +160,7 @@ fn cmd_init(root: &Path, output: &Output, args: InitArgs) -> Result<()> {
     let spec_path = util::normalize_spec_path(root, &spec)?;
     cfg.spec = Some(spec_path.to_string_lossy().to_string());
 
+    config::validate(&cfg)?;
     config::write(root, &cfg)?;
     util::extract_assets(root, &ASSETS)?;
 
@@ -243,6 +248,7 @@ fn cmd_validate(root: &Path, output: &Output, args: ValidateArgs) -> Result<()> 
         docker::ensure_available()?;
     }
 
+    config::validate(&cfg)?;
     util::prepare_runtime_dirs(root)?;
     config::write(root, &cfg)?;
 
@@ -302,7 +308,7 @@ fn cmd_validate(root: &Path, output: &Output, args: ValidateArgs) -> Result<()> 
 
     if failures > 0 {
         output.print_error("Validation failed. See dashboard for details.");
-        std::process::exit(1);
+        std::process::exit(EXIT_VALIDATION_FAILURE);
     }
 
     Ok(())
@@ -319,6 +325,22 @@ fn cmd_config(root: &Path, output: &Output, command: Option<ConfigCommand>) -> R
             config::set_value(&mut cfg, &key, value)?;
             config::write(root, &cfg)?;
             output.println(&format!("Updated {}", root.join(CONFIG_FILE).display()));
+        }
+        ConfigCommand::Validate => {
+            let cfg = config::load(root)?;
+            config::validate(&cfg)?;
+            output.println("Config is valid.");
+        }
+        ConfigCommand::ListGenerators => {
+            println!("Server generators:");
+            for g in generators::SERVER_GENERATORS {
+                println!("  {}", g.name);
+            }
+            println!();
+            println!("Client generators:");
+            for g in generators::CLIENT_GENERATORS {
+                println!("  {}", g.name);
+            }
         }
         ConfigCommand::Edit => {
             let path = root.join(CONFIG_FILE);

--- a/src/steps/generate.rs
+++ b/src/steps/generate.rs
@@ -78,7 +78,9 @@ fn run_for_scope(ctx: &ScopeContext) -> Result<bool> {
         Ok(configs) => configs,
         Err(err) => {
             append_error(&error_log, &err.to_string())?;
-            append_status(ctx.root, "generate", ctx.scope, "_config_", "fail", &error_log)?;
+            append_status(
+                ctx.root, "generate", ctx.scope, "_config_", "fail", &error_log,
+            )?;
             return Ok(false);
         }
     };
@@ -105,7 +107,8 @@ fn run_for_scope(ctx: &ScopeContext) -> Result<bool> {
         .replace("  ", " ");
         write_log_header(&log_path, &command_line)?;
 
-        ctx.output.substep_start(&format!("Generate {} {name}", ctx.scope));
+        ctx.output
+            .substep_start(&format!("Generate {} {name}", ctx.scope));
         let mut command = Command::new("docker");
         command
             .arg("run")
@@ -131,7 +134,8 @@ fn run_for_scope(ctx: &ScopeContext) -> Result<bool> {
             if success { "ok" } else { "fail" },
             &log_path,
         )?;
-        ctx.output.substep_finish(&format!("Generate {} {name}", ctx.scope), success);
+        ctx.output
+            .substep_finish(&format!("Generate {} {name}", ctx.scope), success);
         if !success {
             failures += 1;
         }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -4,6 +4,7 @@ mod common;
 use assert_cmd::prelude::*;
 use common::oav_command;
 use predicates::prelude::*;
+use std::fs;
 use tempfile::TempDir;
 
 // ── Existing field validation ───────────────────────────────────────────
@@ -255,4 +256,198 @@ fn set_spectral_image_kebab_case_alias() {
         .assert()
         .success()
         .stdout(predicate::str::contains("custom/spectral:7"));
+}
+
+// ── docker_timeout validation ───────────────────────────────────────────
+
+#[test]
+fn set_docker_timeout_zero_rejected() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "docker_timeout", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be greater than 0"));
+}
+
+#[test]
+fn set_docker_timeout_negative_rejected() {
+    let temp = TempDir::new().unwrap();
+    // clap rejects "-1" as an unexpected argument; use "--" to pass it as a value
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "docker_timeout", "--", "-1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid docker_timeout"));
+}
+
+#[test]
+fn set_docker_timeout_valid_accepted() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "docker_timeout", "120"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn set_docker_timeout_round_trip() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "docker_timeout", "120"])
+        .assert()
+        .success();
+
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "get", "docker_timeout"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("120"));
+}
+
+// ── search_depth validation ─────────────────────────────────────────────
+
+#[test]
+fn set_search_depth_zero_rejected() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "search_depth", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be greater than 0"));
+}
+
+#[test]
+fn set_search_depth_negative_rejected() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "search_depth", "--", "-1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid search_depth"));
+}
+
+#[test]
+fn set_search_depth_valid_accepted() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "search_depth", "6"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn set_search_depth_round_trip() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "search_depth", "6"])
+        .assert()
+        .success();
+
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "get", "search_depth"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("6"));
+}
+
+// ── Kebab-case aliases for new fields ───────────────────────────────────
+
+#[test]
+fn set_docker_timeout_kebab_alias() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "docker-timeout", "60"])
+        .assert()
+        .success();
+
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "get", "docker-timeout"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("60"));
+}
+
+#[test]
+fn set_search_depth_kebab_alias() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "set", "search-depth", "3"])
+        .assert()
+        .success();
+
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "get", "search-depth"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3"));
+}
+
+// ── config validate subcommand ──────────────────────────────────────────
+
+#[test]
+fn config_validate_default_config_ok() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "validate"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("valid"));
+}
+
+#[test]
+fn config_validate_detects_bad_timeout() {
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join(".oavc"), "docker_timeout: 0\n").unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "validate"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "docker_timeout must be greater than 0",
+        ));
+}
+
+#[test]
+fn config_validate_detects_bad_depth() {
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join(".oavc"), "search_depth: 0\n").unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "validate"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "search_depth must be greater than 0",
+        ));
+}
+
+// ── config list-generators subcommand ───────────────────────────────────
+
+#[test]
+fn config_list_generators_shows_all() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["config", "list-generators"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("spring"))
+        .stdout(predicate::str::contains("typescript-axios"));
 }

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -45,3 +45,26 @@ fn invalid_client_generators_rejected() {
             "Unsupported client generator: 'fake'",
         ));
 }
+
+#[test]
+fn search_depth_zero_rejected() {
+    let temp = TempDir::new().unwrap();
+    fs::copy(fixture_path("valid.yml"), temp.path().join("openapi.yaml")).unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["init", "--search-depth", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be greater than 0"));
+}
+
+#[test]
+fn search_depth_valid_accepted() {
+    let temp = TempDir::new().unwrap();
+    fs::copy(fixture_path("valid.yml"), temp.path().join("openapi.yaml")).unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["init", "--spec", "openapi.yaml", "--search-depth", "2"])
+        .assert()
+        .success();
+}

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -61,6 +61,42 @@ fn invalid_linter_flag_rejected() {
         .stderr(predicate::str::contains("invalid value 'eslint'"));
 }
 
+#[test]
+fn docker_timeout_zero_rejected() {
+    let temp = TempDir::new().unwrap();
+    fs::copy(fixture_path("valid.yml"), temp.path().join("openapi.yaml")).unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["validate", "--docker-timeout", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be greater than 0"));
+}
+
+#[test]
+fn search_depth_zero_rejected() {
+    let temp = TempDir::new().unwrap();
+    fs::copy(fixture_path("valid.yml"), temp.path().join("openapi.yaml")).unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["validate", "--search-depth", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must be greater than 0"));
+}
+
+#[test]
+fn infra_error_exits_with_code_2() {
+    let temp = TempDir::new().unwrap();
+    // No spec and no .oavc → infra error
+    let output = oav_command()
+        .current_dir(temp.path())
+        .args(["validate"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+}
+
 // ── Docker integration tests ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `config validate` and `config list-generators` subcommands (partially addresses #43)
- Add `config::validate()` post-load validation called at point of use in `cmd_init`/`cmd_validate` (not on load, so `config get`/`config print` still work on partially invalid configs)
- Formalize exit codes: 0 = success, 1 = validation failure, 2 = infrastructure/config error
- Add 19 new integration tests covering `docker_timeout`, `search_depth`, the new subcommands, and exit code behavior (closes #8)

## Test plan

- [x] `cargo build` compiles clean
- [x] `cargo clippy` zero warnings
- [x] `cargo fmt` no changes
- [x] `cargo test` — all 46 tests pass (34 config, 5 init, 7 validate)
- [x] Manual: `oav config validate` on a good config prints success
- [x] Manual: `oav config validate` with `docker_timeout: 0` in `.oavc` reports error
- [x] Manual: `oav config list-generators` shows all generators
- [x] Manual: `oav validate` with missing spec exits code 2

Closes #8, partially addresses #43.