### PR TITLE
Warn about modified generator configs during oav clean

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,7 @@ fn cmd_clean(root: &Path, output: &Output, nuke: bool, yes: bool) -> Result<()> 
 }
 
 fn warn_modified_configs(root: &Path, output: &Output) {
-    let modified = util::find_modified_assets(root, &ASSETS);
+    let modified = util::find_modified_generator_configs(root, &ASSETS);
     if modified.is_empty() {
         return;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -260,7 +260,7 @@ fn select_spec_from_candidates(candidates: Vec<String>, quiet: bool) -> Result<O
 /// Compare on-disk generator configs against embedded defaults.
 /// Returns relative paths (e.g. `generators/server/spring.yaml`) for any files
 /// that differ from the embedded version or exist on disk but not in embedded assets.
-pub fn find_modified_assets(root: &Path, assets: &Dir) -> Vec<String> {
+pub fn find_modified_generator_configs(root: &Path, assets: &Dir) -> Vec<String> {
     let oav_dir = root.join(OAV_DIR);
     let generators_dir = oav_dir.join("generators");
     if !generators_dir.exists() {
@@ -316,13 +316,20 @@ fn collect_extra_files(
     embedded_paths: &std::collections::HashSet<String>,
     modified: &mut Vec<String>,
 ) {
-    for entry in entries.filter_map(Result::ok) {
-        let path = entry.path();
-        if path.is_dir() {
+    for dir_entry in entries.filter_map(Result::ok) {
+        let ft = match dir_entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_symlink() {
+            continue;
+        }
+        let path = dir_entry.path();
+        if ft.is_dir() {
             if let Ok(sub) = fs::read_dir(&path) {
                 collect_extra_files(oav_dir, sub, embedded_paths, modified);
             }
-        } else if path.is_file()
+        } else if ft.is_file()
             && let Ok(rel) = path.strip_prefix(oav_dir)
         {
             let rel_str = rel.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary
- Adds detection of modified/user-created generator configs under `.oav/generators/` before `oav clean` deletes the directory
- Compares on-disk files against embedded defaults (byte comparison) and flags any that differ or have no embedded counterpart
- Prints a warning listing modified files and hints at `generator_overrides` in `.oavc` as the durable alternative
- Applies to both regular `clean` and `--nuke` paths (warning shown before nuke confirmation prompt)

Closes #61