### PR TITLE
Replace deprecated serde_yaml, relax version pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ name = "oav"
 path = "src/bin/oav.rs"
 
 [dependencies]
-anyhow = "1.0.100"
-clap = { version = "4.5.54", features = ["derive"] }
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-console = "0.16.2"
+console = "0.16"
 dialoguer = "0.12"
-include_dir = "0.7.4"
-indicatif = "0.18.3"
-libc = "0.2.180"
-owo-colors = "4.2.3"
-serde = { version = "1.0.228", features = ["derive"] }
+include_dir = "0.7"
+indicatif = "0.18"
+libc = "0.2"
+owo-colors = "4.2"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9.34"
-walkdir = "2.5.0"
+yaml_serde = "0.10"
+walkdir = "2.5"
 
 [profile.release]
 lto = true
@@ -33,7 +33,7 @@ strip = "symbols"
 panic = "abort"
 
 [dev-dependencies]
-assert_cmd = "2.1.2"
-predicates = "3.1.4"
+assert_cmd = "2.1"
+predicates = "3.1"
 serde_json = "1.0"
-tempfile = "3.24.0"
+tempfile = "3.24"

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,13 +151,13 @@ pub fn load(root: &Path) -> Result<Config> {
         return Ok(Config::default());
     }
     let content = fs::read_to_string(&path).context("Failed to read .oavc")?;
-    let config = serde_yaml::from_str(&content).context("Failed to parse .oavc")?;
+    let config = yaml_serde::from_str(&content).context("Failed to parse .oavc")?;
     Ok(config)
 }
 
 pub fn write(root: &Path, config: &Config) -> Result<()> {
     let path = root.join(CONFIG_FILE);
-    let content = serde_yaml::to_string(config).context("Failed to serialize config")?;
+    let content = yaml_serde::to_string(config).context("Failed to serialize config")?;
     fs::write(&path, content).context("Failed to write .oavc")?;
     Ok(())
 }
@@ -223,7 +223,7 @@ fn parse_key(key: &str) -> (&str, Option<&str>) {
 }
 
 fn print_yaml<T: Serialize>(value: &T) -> Result<()> {
-    let yaml = serde_yaml::to_string(value).context("Failed to serialize value")?;
+    let yaml = yaml_serde::to_string(value).context("Failed to serialize value")?;
     // Remove trailing newline and print inline
     print!("{}", yaml.trim_end());
     println!();
@@ -474,12 +474,12 @@ fn parse_yaml_list(raw: &str) -> Result<Vec<String>> {
     if raw.trim().is_empty() {
         return Ok(Vec::new());
     }
-    serde_yaml::from_str(raw).context("Failed to parse as YAML list")
+    yaml_serde::from_str(raw).context("Failed to parse as YAML list")
 }
 
 fn parse_yaml_map(raw: &str) -> Result<HashMap<String, String>> {
     if raw.trim().is_empty() {
         return Ok(HashMap::new());
     }
-    serde_yaml::from_str(raw).context("Failed to parse as YAML map")
+    yaml_serde::from_str(raw).context("Failed to parse as YAML map")
 }

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -51,7 +51,7 @@ pub fn load(root: &Path, dir: &str) -> Result<Vec<CustomGeneratorDef>> {
 
         let content = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        let def: CustomGeneratorDef = serde_yaml::from_str(&content)
+        let def: CustomGeneratorDef = yaml_serde::from_str(&content)
             .with_context(|| format!("Failed to parse {}", path.display()))?;
 
         validate_def(&def, &path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,7 +621,7 @@ fn cmd_config(root: &Path, output: &Output, command: Option<ConfigCommand>) -> R
                     serde_json::to_string_pretty(&cfg).expect("failed to serialize config")
                 );
             } else {
-                let yaml = serde_yaml::to_string(&cfg).context("Failed to serialize config")?;
+                let yaml = yaml_serde::to_string(&cfg).context("Failed to serialize config")?;
                 print!("{yaml}");
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -210,12 +210,12 @@ fn is_openapi_spec(path: &Path) -> bool {
     if file.read_to_string(&mut content).is_err() {
         return false;
     }
-    let doc: serde_yaml::Value = match serde_yaml::from_str(&content) {
+    let doc: yaml_serde::Value = match yaml_serde::from_str(&content) {
         Ok(doc) => doc,
         Err(_) => return false,
     };
     match doc {
-        serde_yaml::Value::Mapping(mapping) => mapping
+        yaml_serde::Value::Mapping(mapping) => mapping
             .keys()
             .filter_map(|key| key.as_str())
             .any(|key| key == "openapi"),


### PR DESCRIPTION
## Summary

- Replace `serde_yaml` (archived, `0.9.34+deprecated`) with `yaml_serde` (`0.10.3`), maintained by The YAML Organization — drop-in compatible API
- Relax exact version pins (e.g. `1.0.100`) to semver-compatible ranges (e.g. `1.0`) across all dependencies, allowing automatic patch updates
- Regenerate `Cargo.lock` with latest compatible versions

Closes #57