### PR TITLE
Support validating specs from a URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ owo-colors = "4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
+ureq = "3"
 yaml_serde = "0.10"
 walkdir = "2.5"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub enum Commands {
     },
     /// Run lint, generate, and compile steps
     Validate {
-        /// Path to OpenAPI spec (overrides .oavc)
+        /// Path or URL to OpenAPI spec (overrides .oavc)
         #[arg(long)]
         spec: Option<String>,
         /// Validation mode: server, client, or both

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,235 @@
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::output::Output;
+use crate::util;
+
+/// Fetch a spec from a URL and write it to `.oav/fetched-spec.{ext}`.
+/// Returns the path to the fetched file, relative to `root`.
+pub fn fetch_spec(root: &Path, url: &str, output: &Output) -> Result<PathBuf> {
+    validate_url(url)?;
+
+    let spinner = output.start_spinner(&format!("Fetching spec from {url}"));
+
+    let response = ureq::get(url)
+        .call()
+        .with_context(|| format!("Failed to fetch spec from {url}"))?;
+
+    let status = response.status();
+    if status.as_u16() >= 300 {
+        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
+        bail!("Failed to fetch spec from {url}: HTTP {status}");
+    }
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let body = response
+        .into_body()
+        .read_to_string()
+        .with_context(|| format!("Failed to read response body from {url}"))?;
+
+    if body.trim().is_empty() {
+        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
+        bail!("Fetched spec from {url} is empty");
+    }
+
+    let ext = detect_extension(url, &content_type, &body);
+    let is_json = ext == "json";
+
+    if !util::looks_like_openapi(&body, is_json) {
+        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
+        bail!("Fetched content from {url} does not appear to be an OpenAPI spec");
+    }
+
+    let dest = root.join(util::OAV_DIR).join(format!("fetched-spec.{ext}"));
+    fs::write(&dest, &body)
+        .with_context(|| format!("Failed to write fetched spec to {}", dest.display()))?;
+
+    output.finish_spinner(spinner.as_ref(), "Fetched spec", true);
+
+    // Return the path relative to root
+    let relative = dest
+        .strip_prefix(root)
+        .context("Fetched spec path must be inside the repository")?;
+    Ok(relative.to_path_buf())
+}
+
+/// Returns `true` if the string looks like a URL (any scheme with `://`).
+pub fn looks_like_url(s: &str) -> bool {
+    s.contains("://")
+}
+
+/// Returns `true` if the string is a supported (HTTP/HTTPS) URL.
+pub fn is_http_url(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://")
+}
+
+fn validate_url(url: &str) -> Result<()> {
+    if !is_http_url(url) {
+        bail!("Spec URL must use HTTP or HTTPS");
+    }
+    Ok(())
+}
+
+/// Detect the file extension for the fetched spec.
+/// Priority: URL path extension > Content-Type header > content sniffing.
+fn detect_extension(url: &str, content_type: &str, body: &str) -> &'static str {
+    // 1. URL path extension
+    if let Some(ext) = extension_from_url(url) {
+        return ext;
+    }
+
+    // 2. Content-Type header
+    if let Some(ext) = extension_from_content_type(content_type) {
+        return ext;
+    }
+
+    // 3. Content sniffing
+    if body.trim_start().starts_with('{') {
+        "json"
+    } else {
+        "yaml"
+    }
+}
+
+fn extension_from_url(url: &str) -> Option<&'static str> {
+    // Strip query string and fragment
+    let path = url.split('?').next().unwrap_or(url);
+    let path = path.split('#').next().unwrap_or(path);
+
+    if path.ends_with(".json") {
+        Some("json")
+    } else if path.ends_with(".yaml") || path.ends_with(".yml") {
+        Some("yaml")
+    } else {
+        None
+    }
+}
+
+fn extension_from_content_type(ct: &str) -> Option<&'static str> {
+    let lower = ct.to_lowercase();
+    if lower.contains("json") {
+        Some("json")
+    } else if lower.contains("yaml") || lower.contains("yml") {
+        Some("yaml")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extension_from_url() {
+        assert_eq!(
+            extension_from_url("https://example.com/spec.json"),
+            Some("json")
+        );
+        assert_eq!(
+            extension_from_url("https://example.com/spec.yaml"),
+            Some("yaml")
+        );
+        assert_eq!(
+            extension_from_url("https://example.com/spec.yml"),
+            Some("yaml")
+        );
+        assert_eq!(
+            extension_from_url("https://example.com/spec.json?v=1"),
+            Some("json")
+        );
+        assert_eq!(
+            extension_from_url("https://example.com/spec.yaml#section"),
+            Some("yaml")
+        );
+        assert_eq!(
+            extension_from_url("https://example.com/api/v3/openapi"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extension_from_content_type() {
+        assert_eq!(
+            extension_from_content_type("application/json"),
+            Some("json")
+        );
+        assert_eq!(
+            extension_from_content_type("application/x-yaml"),
+            Some("yaml")
+        );
+        assert_eq!(
+            extension_from_content_type("text/yaml; charset=utf-8"),
+            Some("yaml")
+        );
+        assert_eq!(extension_from_content_type("text/plain"), None);
+    }
+
+    #[test]
+    fn test_detect_extension_url_takes_priority() {
+        assert_eq!(
+            detect_extension("https://example.com/spec.json", "text/yaml", "openapi: 3.0"),
+            "json"
+        );
+    }
+
+    #[test]
+    fn test_detect_extension_content_type_fallback() {
+        assert_eq!(
+            detect_extension(
+                "https://example.com/api/spec",
+                "application/json",
+                "openapi: 3.0"
+            ),
+            "json"
+        );
+    }
+
+    #[test]
+    fn test_detect_extension_sniff_fallback() {
+        assert_eq!(
+            detect_extension(
+                "https://example.com/api/spec",
+                "text/plain",
+                r#"{"openapi":"3.0"}"#
+            ),
+            "json"
+        );
+        assert_eq!(
+            detect_extension("https://example.com/api/spec", "text/plain", "openapi: 3.0"),
+            "yaml"
+        );
+    }
+
+    #[test]
+    fn test_looks_like_url() {
+        assert!(looks_like_url("ftp://example.com/spec.yaml"));
+        assert!(looks_like_url("https://example.com/spec.yaml"));
+        assert!(looks_like_url("http://example.com/spec.yaml"));
+        assert!(!looks_like_url("/local/path/spec.yaml"));
+        assert!(!looks_like_url("relative/path.yaml"));
+    }
+
+    #[test]
+    fn test_is_http_url() {
+        assert!(!is_http_url("ftp://example.com/spec.yaml"));
+        assert!(!is_http_url("/local/path/spec.yaml"));
+        assert!(is_http_url("https://example.com/spec.yaml"));
+        assert!(is_http_url("http://example.com/spec.yaml"));
+    }
+
+    #[test]
+    fn test_validate_url_rejects_non_http() {
+        assert!(validate_url("ftp://example.com/spec.yaml").is_err());
+        assert!(validate_url("/local/path/spec.yaml").is_err());
+        assert!(validate_url("https://example.com/spec.yaml").is_ok());
+        assert!(validate_url("http://example.com/spec.yaml").is_ok());
+    }
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,24 +1,60 @@
 use anyhow::{Context, Result, bail};
+use indicatif::ProgressBar;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::output::Output;
 use crate::util;
+
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Guard that clears a spinner on drop, ensuring it never leaks on early returns.
+struct SpinnerGuard<'a> {
+    spinner: Option<ProgressBar>,
+    output: &'a Output,
+    label: &'static str,
+    success: bool,
+}
+
+impl<'a> SpinnerGuard<'a> {
+    fn finish(&mut self, label: &'static str, success: bool) {
+        self.label = label;
+        self.success = success;
+    }
+}
+
+impl Drop for SpinnerGuard<'_> {
+    fn drop(&mut self) {
+        self.output
+            .finish_spinner(self.spinner.as_ref(), self.label, self.success);
+    }
+}
 
 /// Fetch a spec from a URL and write it to `.oav/fetched-spec.{ext}`.
 /// Returns the path to the fetched file, relative to `root`.
 pub fn fetch_spec(root: &Path, url: &str, output: &Output) -> Result<PathBuf> {
     validate_url(url)?;
 
-    let spinner = output.start_spinner(&format!("Fetching spec from {url}"));
+    let mut guard = SpinnerGuard {
+        spinner: output.start_spinner(&format!("Fetching spec from {url}")),
+        output,
+        label: "Fetch failed",
+        success: false,
+    };
 
-    let response = ureq::get(url)
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(FETCH_TIMEOUT))
+        .build()
+        .into();
+
+    let response = agent
+        .get(url)
         .call()
         .with_context(|| format!("Failed to fetch spec from {url}"))?;
 
     let status = response.status();
     if status.as_u16() >= 300 {
-        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
         bail!("Failed to fetch spec from {url}: HTTP {status}");
     }
 
@@ -35,7 +71,6 @@ pub fn fetch_spec(root: &Path, url: &str, output: &Output) -> Result<PathBuf> {
         .with_context(|| format!("Failed to read response body from {url}"))?;
 
     if body.trim().is_empty() {
-        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
         bail!("Fetched spec from {url} is empty");
     }
 
@@ -43,7 +78,6 @@ pub fn fetch_spec(root: &Path, url: &str, output: &Output) -> Result<PathBuf> {
     let is_json = ext == "json";
 
     if !util::looks_like_openapi(&body, is_json) {
-        output.finish_spinner(spinner.as_ref(), "Fetch failed", false);
         bail!("Fetched content from {url} does not appear to be an OpenAPI spec");
     }
 
@@ -51,7 +85,7 @@ pub fn fetch_spec(root: &Path, url: &str, output: &Output) -> Result<PathBuf> {
     fs::write(&dest, &body)
         .with_context(|| format!("Failed to write fetched spec to {}", dest.display()))?;
 
-    output.finish_spinner(spinner.as_ref(), "Fetched spec", true);
+    guard.finish("Fetched spec", true);
 
     // Return the path relative to root
     let relative = dest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod completions;
 mod config;
 mod custom;
 mod docker;
+mod fetch;
 mod generators;
 mod json_report;
 mod output;
@@ -406,7 +407,12 @@ fn cmd_validate(root: &Path, output: &Output, args: ValidateArgs) -> Result<()> 
         if trimmed.is_empty() {
             bail!("--spec cannot be blank");
         }
-        cfg.spec = Some(trimmed);
+        if fetch::looks_like_url(&trimmed) {
+            let fetched = fetch::fetch_spec(root, &trimmed, output)?;
+            cfg.spec = Some(fetched.to_string_lossy().to_string());
+        } else {
+            cfg.spec = Some(trimmed);
+        }
     }
     if let Some(m) = args.mode {
         cfg.mode = m;

--- a/src/util.rs
+++ b/src/util.rs
@@ -208,9 +208,21 @@ fn is_json(path: &Path) -> bool {
     )
 }
 
+/// Check whether content (as a string) looks like an OpenAPI spec.
+/// For JSON content, looks for `"openapi":` as a key. For YAML, looks for
+/// `openapi:`. Only the first 512 bytes need to be checked.
+pub fn looks_like_openapi(content: &str, json: bool) -> bool {
+    let head: String = content.chars().take(512).collect();
+    if json {
+        let stripped: String = head.chars().filter(|c| !c.is_whitespace()).collect();
+        stripped.contains("\"openapi\":")
+    } else {
+        head.contains("openapi:")
+    }
+}
+
 /// Heuristic check for OpenAPI specs: reads only the first 512 bytes and
-/// scans for an `openapi` key. For JSON this looks for `"openapi":`, for
-/// YAML it looks for `openapi:`. This avoids parsing potentially large
+/// scans for an `openapi` key. This avoids parsing potentially large
 /// files that happen to have a matching extension.
 fn is_openapi_spec(path: &Path) -> bool {
     let mut file = match File::open(path) {
@@ -223,14 +235,7 @@ fn is_openapi_spec(path: &Path) -> bool {
         Err(_) => return false,
     };
     let head = String::from_utf8_lossy(&buf[..n]);
-    if is_json(path) {
-        // Match `"openapi"` as a JSON key — require a colon after the key
-        // to avoid false positives when the word appears as a string value.
-        let stripped: String = head.chars().filter(|c| !c.is_whitespace()).collect();
-        stripped.contains("\"openapi\":")
-    } else {
-        head.contains("openapi:")
-    }
+    looks_like_openapi(&head, is_json(path))
 }
 
 fn should_skip_entry(entry: &walkdir::DirEntry) -> bool {

--- a/src/util.rs
+++ b/src/util.rs
@@ -210,7 +210,7 @@ fn is_json(path: &Path) -> bool {
 
 /// Check whether content (as a string) looks like an OpenAPI spec.
 /// For JSON content, looks for `"openapi":` as a key. For YAML, looks for
-/// `openapi:`. Only the first 512 bytes need to be checked.
+/// `openapi:`. Only inspects the first 512 characters.
 pub fn looks_like_openapi(content: &str, json: bool) -> bool {
     let head: String = content.chars().take(512).collect();
     if json {
@@ -399,4 +399,44 @@ pub fn append_error(log_path: &Path, message: &str) -> Result<()> {
         .context("Failed to write error log")?;
     writeln!(file, "{message}")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_openapi_yaml_positive() {
+        assert!(looks_like_openapi(
+            "openapi: 3.0.3\ninfo:\n  title: Test",
+            false
+        ));
+    }
+
+    #[test]
+    fn looks_like_openapi_yaml_negative() {
+        assert!(!looks_like_openapi("name: not a spec\nversion: 1.0", false));
+    }
+
+    #[test]
+    fn looks_like_openapi_json_positive() {
+        assert!(looks_like_openapi(
+            r#"{"openapi": "3.0.3", "info": {}}"#,
+            true
+        ));
+    }
+
+    #[test]
+    fn looks_like_openapi_json_negative() {
+        assert!(!looks_like_openapi(r#"{"name": "not a spec"}"#, true));
+    }
+
+    #[test]
+    fn looks_like_openapi_json_value_not_key() {
+        // "openapi" as a value, not a key — should not match
+        assert!(!looks_like_openapi(
+            r#"{"type": "openapi", "name": "tool"}"#,
+            true
+        ));
+    }
 }

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -98,6 +98,119 @@ fn infra_error_exits_with_code_2() {
     assert_eq!(output.status.code(), Some(2));
 }
 
+// ── URL spec tests (no Docker required) ─────────────────────────────────
+
+#[test]
+fn spec_url_non_http_rejected() {
+    let temp = TempDir::new().unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args(["validate", "--spec", "ftp://example.com/spec.yaml"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Spec URL must use HTTP or HTTPS"));
+}
+
+#[test]
+fn spec_url_unreachable_host_fails() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".oav")).unwrap();
+    oav_command()
+        .current_dir(temp.path())
+        .args([
+            "validate",
+            "--spec",
+            "https://host.invalid.test/openapi.yaml",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to fetch spec from"));
+}
+
+#[test]
+#[ignore]
+fn spec_url_fetches_remote_json() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let root = temp.path();
+    fs::create_dir_all(root.join(".oav"))?;
+
+    // This test only verifies the fetch + spec resolution succeeds.
+    // It will fail at the Docker step (no Docker in CI for non-ignored tests),
+    // but the fetched file should exist.
+    let output = oav_command()
+        .current_dir(root)
+        .args([
+            "validate",
+            "--spec",
+            "https://petstore3.swagger.io/api/v3/openapi.json",
+            "--skip-lint",
+            "--skip-generate",
+            "--skip-compile",
+        ])
+        .output()?;
+
+    // The fetched spec should have been written
+    let fetched = root.join(".oav").join("fetched-spec.json");
+    assert!(
+        fetched.exists(),
+        "fetched spec should exist at .oav/fetched-spec.json"
+    );
+
+    let content = fs::read_to_string(&fetched)?;
+    assert!(
+        content.contains("\"openapi\""),
+        "fetched content should look like an OpenAPI spec"
+    );
+
+    // If Docker isn't available the command may fail at a later stage,
+    // but the fetch itself should have succeeded (no "Failed to fetch" in stderr).
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Failed to fetch"),
+        "fetch should succeed; stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn spec_url_fetches_remote_yaml() -> Result<(), Box<dyn Error>> {
+    let temp = TempDir::new()?;
+    let root = temp.path();
+    fs::create_dir_all(root.join(".oav"))?;
+
+    let output = oav_command()
+        .current_dir(root)
+        .args([
+            "validate",
+            "--spec",
+            "https://petstore3.swagger.io/api/v3/openapi.yaml",
+            "--skip-lint",
+            "--skip-generate",
+            "--skip-compile",
+        ])
+        .output()?;
+
+    let fetched = root.join(".oav").join("fetched-spec.yaml");
+    assert!(
+        fetched.exists(),
+        "fetched spec should exist at .oav/fetched-spec.yaml"
+    );
+
+    let content = fs::read_to_string(&fetched)?;
+    assert!(
+        content.contains("openapi:"),
+        "fetched content should look like an OpenAPI spec"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Failed to fetch"),
+        "fetch should succeed; stderr: {stderr}"
+    );
+    Ok(())
+}
+
 // ── Docker integration tests ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #73.

- `--spec` now accepts URLs alongside file paths (e.g. `oav validate --spec https://petstore3.swagger.io/api/v3/openapi.json`)
- Fetches the spec to `.oav/fetched-spec.{ext}` and runs it through the existing validation pipeline
- Detects format via URL extension → Content-Type → content sniffing
- Validates fetched content looks like an OpenAPI spec before proceeding
- Uses `ureq` (blocking HTTP, no async runtime) to keep the binary lean
- Non-HTTP schemes (e.g. `ftp://`) are rejected with a clear error